### PR TITLE
image: let mksquashfs4 use all processors

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -227,8 +227,7 @@ $(eval $(foreach S,$(NAND_BLOCKSIZE),$(call Image/mkfs/jffs2-nand/template,$(S))
 define Image/mkfs/squashfs-common
 	$(STAGING_DIR_HOST)/bin/mksquashfs4 $(call mkfs_target_dir,$(1)) $@ \
 		-nopad -noappend -root-owned \
-		-comp $(SQUASHFSCOMP) $(SQUASHFSOPT) \
-		-processors $(shell nproc)
+		-comp $(SQUASHFSCOMP) $(SQUASHFSOPT)
 endef
 
 ifeq ($(CONFIG_TARGET_ROOTFS_SECURITY_LABELS),y)


### PR DESCRIPTION
Drop the -processors argument from the mksquashfs4 call, so it will use
all available processors. This dramatically reduces the time to create
squashfs filesystems.

The times below are observed when building an image for my main router,
the WatchGuard Firebox M300 (qoriq target):

Before:
real    4m45,973s

After:
real    0m23,497s

With this commit `mksquashfs` may use more cores than defined via `-j`.
This is the same behaviour as for archive creation of ImageBuilder, SDK
or toolchain. There is no trivial way to limit `mksquashfs` CPU core
usage to the amount of "free" make jobs since two running `mksquashfs`
instances would each run with the total allowed number (-j) of threads.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
[extended reasoning in commit message]
Signed-off-by: Paul Spooren <mail@aparcar.org>
(cherry picked from commit df2ae8826ced4f374bcb693b44d8a113ad150d70)