### PR TITLE
fstools: enable any device with non-MTD rootfs_data volume

### DIFF
--- a/package/system/fstools/Makefile
+++ b/package/system/fstools/Makefile
@@ -79,14 +79,14 @@ define Package/block-mount
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=Block device mounting and checking
-  DEPENDS:=+ubox +libubox +libuci +libblobmsg-json +libjson-c
+  DEPENDS:=+ubox +libubox +libuci +libblobmsg-json +libjson-c +fstools
 endef
 
 define Package/blockd
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=Block device automounting
-  DEPENDS:=+block-mount +fstools +libubus +kmod-fs-autofs4 +libblobmsg-json +libjson-c
+  DEPENDS:=+block-mount +libubus +kmod-fs-autofs4 +libblobmsg-json +libjson-c
 endef
 
 define Package/fstools/install

--- a/package/system/fstools/patches/100-fstools-support-extroot-for-non-MTD-rootfs_data.patch
+++ b/package/system/fstools/patches/100-fstools-support-extroot-for-non-MTD-rootfs_data.patch
@@ -1,0 +1,123 @@
+From: Qi Liu <liuqi_colin@msn.com>
+
+In order to support extroot, block extroot command has to be able to
+discover and properly mount the rootfs_data volume in order to discover
+the extroot volume. Currently this process can only discover MTD devices.
+This patch leverages libfstools in a similar way as mount_root to
+discover, initialize, and mount rootfs_data volume. It would enable any
+device with non-MTD rootfs_data volume to support extroot, including x86.
+
+Signed-off-by: Qi Liu <liuqi_colin@msn.com>
+---
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -77,9 +77,9 @@ INSTALL(TARGETS blockd RUNTIME DESTINATION sbin)
+ ADD_EXECUTABLE(block block.c probe.c probe-libblkid.c)
+ IF(DEFINED CMAKE_UBIFS_EXTROOT)
+ 	ADD_DEFINITIONS(-DUBIFS_EXTROOT)
+-	TARGET_LINK_LIBRARIES(block blkid-tiny dl uci ubox ubus blobmsg_json ubi-utils ${json})
++	TARGET_LINK_LIBRARIES(block blkid-tiny dl fstools uci ubox ubus blobmsg_json ubi-utils ${json})
+ ELSE(DEFINED CMAKE_UBIFS_EXTROOT)
+-	TARGET_LINK_LIBRARIES(block blkid-tiny dl uci ubox ubus blobmsg_json ${json})
++	TARGET_LINK_LIBRARIES(block blkid-tiny dl fstools uci ubox ubus blobmsg_json ${json})
+ ENDIF(DEFINED CMAKE_UBIFS_EXTROOT)
+ INSTALL(TARGETS block RUNTIME DESTINATION sbin)
+ 
+--- a/block.c
++++ b/block.c
+@@ -46,6 +46,9 @@
+ #include <libubox/vlist.h>
+ #include <libubus.h>
+ 
++#include "libfstools/fstype.h"
++#include "libfstools/volume.h"
++
+ #include "probe.h"
+ 
+ #define AUTOFS_MOUNT_PATH       "/tmp/run/blockd/"
+@@ -1600,6 +1603,44 @@ static int main_extroot(int argc, char **argv)
+        }
+ #endif
+ 
++	/* Find volume using libfstools */
++	struct volume *data = volume_find("rootfs_data");
++	if (data) {
++		volume_init(data);
++
++		switch (volume_identify(data)) {
++			case FS_EXT4: {
++				char cfg[] = "/tmp/ext4_cfg";
++
++				/* Mount volume and try extroot (using fstab from that vol) */
++				mkdir_p(cfg, 0755);
++				if (!mount(data->blk, cfg, "ext4", MS_NOATIME, NULL)) {
++					err = mount_extroot(cfg);
++					umount2(cfg, MNT_DETACH);
++				}
++				if (err < 0)
++					rmdir("/tmp/overlay");
++				rmdir(cfg);
++				return err;
++			}
++
++			case FS_F2FS: {
++				char cfg[] = "/tmp/f2fs_cfg";
++
++				/* Mount volume and try extroot (using fstab from that vol) */
++				mkdir_p(cfg, 0755);
++				if (!mount(data->blk, cfg, "f2fs", MS_NOATIME, NULL)) {
++					err = mount_extroot(cfg);
++					umount2(cfg, MNT_DETACH);
++				}
++				if (err < 0)
++					rmdir("/tmp/overlay");
++				rmdir(cfg);
++				return err;
++			}
++		}
++	}
++
+ 	/* As a last resort look for /etc/config/fstab on "rootfs" partition */
+ 	return mount_extroot(NULL);
+ }
+--- /dev/null
++++ b/libfstools/fstype.h
+@@ -0,0 +1,13 @@
++#ifndef _FS_TYPE_H__
++#define _FS_TYPE_H__
++enum {
++	FS_NONE,
++	FS_SNAPSHOT,
++	FS_JFFS2,
++	FS_DEADCODE,
++	FS_UBIFS,
++	FS_F2FS,
++	FS_EXT4,
++	FS_TARGZ,
++};
++#endif
+--- a/libfstools/libfstools.h
++++ b/libfstools/libfstools.h
+@@ -18,20 +18,10 @@
+ #include <libubox/blob.h>
+ #include <libubox/ulog.h>
+ #include <libubox/utils.h>
++#include "fstype.h"
+ 
+ struct volume;
+ 
+-enum {
+-	FS_NONE,
+-	FS_SNAPSHOT,
+-	FS_JFFS2,
+-	FS_DEADCODE,
+-	FS_UBIFS,
+-	FS_F2FS,
+-	FS_EXT4,
+-	FS_TARGZ,
+-};
+-
+ enum fs_state {
+ 	FS_STATE_UNKNOWN,
+ 	FS_STATE_PENDING,


### PR DESCRIPTION
Fixes: #673
(cherry picked from commit 90ace9890f07c710c7659142135231a9cf7bc747)
[rebased patch]
Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>