### PR TITLE
openssl: bump to 1.1.1p

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=o
+PKG_BUGFIX:=p
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
@@ -27,7 +27,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
+PKG_HASH:=bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Changes between 1.1.1o and 1.1.1p [21 Jun 2022]

  *) In addition to the c_rehash shell command injection identified in
     CVE-2022-1292, further bugs where the c_rehash script does not
     properly sanitise shell metacharacters to prevent command injection have been
     fixed.

     When the CVE-2022-1292 was fixed it was not discovered that there
     are other places in the script where the file names of certificates
     being hashed were possibly passed to a command executed through the shell.

     This script is distributed by some operating systems in a manner where
     it is automatically executed.  On such operating systems, an attacker
     could execute arbitrary commands with the privileges of the script.

     Use of the c_rehash script is considered obsolete and should be replaced
     by the OpenSSL rehash command line tool.
     (CVE-2022-2068)
     [Daniel Fiala, Tomáš Mráz]

  *) When OpenSSL TLS client is connecting without any supported elliptic
     curves and TLS-1.3 protocol is disabled the connection will no longer fail
     if a ciphersuite that does not use a key exchange based on elliptic
     curves can be negotiated.
     [Tomáš Mráz]

Signed-off-by: Andre Heider <a.heider@gmail.com>
Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>
(cherry picked from commit 06892d7fbbe2d6e316d3daacf5c92d90c19dac25)