### PR TITLE
r8168: fix typo error

### DIFF
--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -8,7 +8,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=r8168
 PKG_VERSION:=8.050.03
-PKG_RELEASE:=$(AUTORELEAE)
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/BROBIRD/openwrt-r8168.git
@@ -16,8 +16,6 @@ PKG_SOURCE_VERSION:=ddfaceacd1b7ed2857fb995642a8ffb1fc37e989
 PKG_MIRROR_HASH:=5428f60dc33e9503c6cfdf690c00077149dce24cbb0591129d905b9f1aad9202
 
 PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-
-MAKE_PATH:=src
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -35,20 +33,8 @@ define Package/r8168/description
   This package contains a driver for Realtek r8168 chipsets.
 endef
 
-R8168_MAKEOPTS= -C $(PKG_BUILD_DIR)/src \
-	PATH="$(TARGET_PATH)" \
-	ARCH="$(LINUX_KARCH)" \
-	CROSS_COMPILE="$(TARGET_CROSS)" \
-	TARGET="$(HAL_TARGET)" \
-	TOOLPREFIX="$(KERNEL_CROSS)" \
-	TOOLPATH="$(KERNEL_CROSS)" \
-	KERNELPATH="$(LINUX_DIR)" \
-	KERNELDIR="$(LINUX_DIR)" \
-	LDOPTS=" " \
-	DOMULTI=1
-
 define Build/Compile
-	$(MAKE) $(R8168_MAKEOPTS) modules
+	+$(KERNEL_MAKE) M=$(PKG_BUILD_DIR)/src modules
 endef
 
 $(eval $(call KernelPackage,r8168))


### PR DESCRIPTION
Switched to use KERNEL_MAKE while at it.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>